### PR TITLE
Fixes #12: Give signature image a `maxWidth`

### DIFF
--- a/src/Letter.ts
+++ b/src/Letter.ts
@@ -12,8 +12,8 @@ export type LetterProps = {
     content: PdfMakeContent;
     signature: Signature;
 };
-// The `marginTop` is missing in the type definitions.
-type PdfMakeSignature = (ContentText | ContentImage) & { marginTop: number };
+// `marginTop` and `maxWidth` are missing in the type definitions.
+type PdfMakeSignature = (ContentText | ContentImage) & { marginTop?: number; maxWidth?: number };
 
 const _parseTags = (content: string) => {
     if (!content) return [];
@@ -96,7 +96,7 @@ export class Letter {
                 return { text: signature.name, marginTop: mm2pt(2) };
             case 'image':
                 return [
-                    { image: signature.value, marginTop: mm2pt(5) },
+                    { image: signature.value, maxWidth: mm2pt(60), marginTop: mm2pt(5) },
                     ...(signature.name ? [{ text: signature.name, marginTop: mm2pt(1) }] : []),
                 ];
         }


### PR DESCRIPTION
The problem of the huge signature was caused by #3. Removing the fixed `width` from the signature caused the image to scale to the page width (even though the docs say this should mean the image's original size *shrug*).

Instead, we now set a `maxWidth`, which solves both problems. I haven't actually found any documentation for this feature but it was implemented in bpampuch/pdfmake#938.